### PR TITLE
only do multi swath product check when processing multiple swaths

### DIFF
--- a/sar-op-sentinel1/src/main/java/eu/esa/sar/sentinel1/gpf/TOPSARSplitOp.java
+++ b/sar-op-sentinel1/src/main/java/eu/esa/sar/sentinel1/gpf/TOPSARSplitOp.java
@@ -101,7 +101,6 @@ public final class TOPSARSplitOp extends Operator {
             final InputProductValidator validator = new InputProductValidator(sourceProduct);
             validator.checkIfSARProduct();
             validator.checkIfSentinel1Product();
-            validator.checkIfMultiSwathTOPSARProduct();
             validator.checkProductType(new String[]{"SLC"});
             validator.checkAcquisitionMode(new String[]{"IW", "EW"});
 
@@ -113,6 +112,9 @@ public final class TOPSARSplitOp extends Operator {
 
             final Sentinel1Utils su = new Sentinel1Utils(sourceProduct);
             subSwathInfo = su.getSubSwath();
+            if (subSwathInfo != null && subSwathInfo.length > 1) {
+                validator.checkIfMultiSwathTOPSARProduct();
+            }
             for (int i = 0; i < subSwathInfo.length; i++) {
                 if (subSwathInfo[i].subSwathName.contains(subswath)) {
                     subSwathIndex = i + 1;

--- a/sar-op-sentinel1/src/main/java/eu/esa/sar/sentinel1/gpf/TOPSARSplitOp.java
+++ b/sar-op-sentinel1/src/main/java/eu/esa/sar/sentinel1/gpf/TOPSARSplitOp.java
@@ -104,7 +104,7 @@ public final class TOPSARSplitOp extends Operator {
             final InputProductValidator validator = new InputProductValidator(sourceProduct);
             validator.checkIfSARProduct();
             validator.checkIfSentinel1Product();
-            if (!enableSingleSwathProcessing) {
+            if (!enableSingleSwathMode) {
                 validator.checkIfMultiSwathTOPSARProduct();
             }
             validator.checkProductType(new String[]{"SLC"});

--- a/sar-op-sentinel1/src/main/java/eu/esa/sar/sentinel1/gpf/TOPSARSplitOp.java
+++ b/sar-op-sentinel1/src/main/java/eu/esa/sar/sentinel1/gpf/TOPSARSplitOp.java
@@ -66,6 +66,9 @@ public final class TOPSARSplitOp extends Operator {
     @Parameter(description = "The list of source bands.", label = "Subswath")
     private String subswath = null;
 
+    @Parameter(description = "Enable processing of single-swath products", defaultValue = "false", label = "Enable Single Swath Mode")
+    private boolean enableSingleSwathMode = false;
+
     @Parameter(description = "The list of polarisations", label = "Polarisations")
     private String[] selectedPolarisations;
 
@@ -101,6 +104,9 @@ public final class TOPSARSplitOp extends Operator {
             final InputProductValidator validator = new InputProductValidator(sourceProduct);
             validator.checkIfSARProduct();
             validator.checkIfSentinel1Product();
+            if (!enableSingleSwathProcessing) {
+                validator.checkIfMultiSwathTOPSARProduct();
+            }
             validator.checkProductType(new String[]{"SLC"});
             validator.checkAcquisitionMode(new String[]{"IW", "EW"});
 

--- a/sar-op-sentinel1/src/main/java/eu/esa/sar/sentinel1/gpf/TOPSARSplitOp.java
+++ b/sar-op-sentinel1/src/main/java/eu/esa/sar/sentinel1/gpf/TOPSARSplitOp.java
@@ -112,9 +112,9 @@ public final class TOPSARSplitOp extends Operator {
 
             final Sentinel1Utils su = new Sentinel1Utils(sourceProduct);
             subSwathInfo = su.getSubSwath();
-            if (subSwathInfo != null && subSwathInfo.length > 1) {
-                validator.checkIfMultiSwathTOPSARProduct();
-            }
+            //if (subSwathInfo != null && subSwathInfo.length > 1) {
+            //   validator.checkIfMultiSwathTOPSARProduct();
+            //}
             for (int i = 0; i < subSwathInfo.length; i++) {
                 if (subSwathInfo[i].subSwathName.contains(subswath)) {
                     subSwathIndex = i + 1;


### PR DESCRIPTION
At the beginning of the **Top Sar Split Operation**, there are some checks to validate the structure of the product.
Once check is looking for all subswaths (`checkIfMultiSwathTOPSARProduct`). If there is only one swath and associated metadata in the product folder it will fail.

PROBLEM:
I am running a pipeline where processing time is very important, so I am only downloading and processing single swaths. I don't want to have the extra overhead for the other swaths if I don't even need them.
Currently the **Top Sar Split Operation** will fail because it expects a folder with all swaths.

SOLUTION:
Just do the multi swath check if we are indeed processing multiple swaths. I think this is also more logic, because why should we check for multiple swaths if we only want to process one of them.

**This PR adds an if clause to only run the check when its actually needed.**

